### PR TITLE
Fix for Python 3.10

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -426,7 +426,7 @@ class UnknownExtra(ResolutionError):
 
 _provider_factories = {}
 
-PY_MAJOR = sys.version[:3]
+PY_MAJOR = '{}.{}'.format(*sys.version_info)
 EGG_DIST = 3
 BINARY_DIST = 2
 SOURCE_DIST = 1

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -107,7 +107,7 @@ class TestDistro:
         self.checkFooPkg(d)
 
         d = Distribution("/some/path")
-        assert d.py_version == sys.version[:3]
+        assert d.py_version == '{}.{}'.format(*sys.version_info)
         assert d.platform is None
 
     def testDistroParse(self):


### PR DESCRIPTION
Changes proposed in this pull request:

 * Fix for Python 3.10
 * Inspired by https://github.com/pypa/setuptools/pull/1824


```python
Python 3.7.4 (default, Jul  9 2019, 18:13:23)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version
'3.7.4 (default, Jul  9 2019, 18:13:23) \n[Clang 10.0.1 (clang-1001.0.46.4)]'
>>> sys.version[:3]
'3.7'
>>> v310 = '3.10.4 (default, Jul  9 2019, 18:13:23) \n[Clang 10.0.1 (clang-1001.0.46.4)]'
>>> v310[:3]
'3.1'
```

