### PR TITLE
Sync with latest published version + minimal changes that allow tests to pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-A (still deprecated) copy of ``pkg_resources`` as found in Setuptools 80. Made available for a compatibility install in environments that previously dependended on Setuptools for this functionality. In other words, DO NOT USE.
+A (still deprecated) copy of ``pkg_resources`` as found in Setuptools v81.0.0.
+Made available for a compatibility install in environments that previously dependended on Setuptools for this functionality.
+
+In other words, ***DO NOT USE***.
+
+Projects must migrate away from ``pkg_resources``. The recommended replacements are:
+
+* Resource access: `importlib.resources`
+  (or its backport `importlib_resources`).
+* Distribution metadata & entry points: use `importlib.metadata`
+  (or its backport `importlib_metadata`).
+* Requirement and version parsing: use `packaging`.
+  This includes parsing and evaluating ``extras`` and markers via
+  ``packaging.requirements.Requirement`` and ``packaging.markers.Marker``.
+  Note that automatic installation or detection of extras is not provided;
+  projects requiring that behaviour must implement it themselves using
+  a combination of ``packaging``, ``importlib.metadata`` and other tools
+  as building blocks.
+* Coexistence of multiple versions of a package: please consider using a different
+  approach, as this functionality is not supported by Python itself.
+  Alternatives include isolated environments and orchestration tools
+  (`venv`, `tox`, `nox`, etc.).
+* Handling of `.egg` distributions: please consider using a different
+  approach, as the `.egg` and `easy_install` mechanisms have also been
+  discontinued.
+  Please use currently supported packaging formats
+  and build/installation workflows (PEP 517).

--- a/__init__.py
+++ b/__init__.py
@@ -97,8 +97,11 @@ if TYPE_CHECKING:
 
 warnings.warn(
     "pkg_resources is deprecated as an API. "
-    "See https://setuptools.pypa.io/en/latest/pkg_resources.html",
-    DeprecationWarning,
+    "See https://setuptools.pypa.io/en/latest/pkg_resources.html. "
+    "The pkg_resources package is slated for removal as early as "
+    "2025-11-30. Refrain from using this package or pin to "
+    "Setuptools<81.",
+    UserWarning,
     stacklevel=2,
 )
 
@@ -128,7 +131,9 @@ class _ZipLoaderModule(Protocol):
     __loader__: zipimport.zipimporter
 
 
-_PEP440_FALLBACK = re.compile(r"^v?(?P<safe>(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*)", re.I)
+_PEP440_FALLBACK = re.compile(
+    r"^v?(?P<safe>(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*)", re.IGNORECASE
+)
 
 
 class PEP440Warning(RuntimeWarning):

--- a/__init__.py
+++ b/__init__.py
@@ -66,7 +66,7 @@ from typing import (
     overload,
 )
 
-# workaround for #4476
+# workaround for pypa/setuptools#4476
 sys.modules.pop('backports', None)
 
 # capture these to bypass sandboxing

--- a/__init__.py
+++ b/__init__.py
@@ -66,7 +66,6 @@ from typing import (
     overload,
 )
 
-sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
 # workaround for #4476
 sys.modules.pop('backports', None)
 

--- a/__init__.py
+++ b/__init__.py
@@ -96,11 +96,10 @@ if TYPE_CHECKING:
     from typing_extensions import Self, TypeAlias
 
 warnings.warn(
-    "pkg_resources is deprecated as an API. "
-    "See https://setuptools.pypa.io/en/latest/pkg_resources.html. "
-    "The pkg_resources package is slated for removal as early as "
-    "2025-11-30. Refrain from using this package or pin to "
-    "Setuptools<81.",
+    "pkg_resources is an obsolete package and should not be used. "
+    "It was removed in Setuptools v82.0.0 and is retained under "
+    "https://github.com/pypa/pkg_resources just for archival purposes. "
+    "The project is not actively maintained and newer code MUST not use it.",
     UserWarning,
     stacklevel=2,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = [
+  "setuptools>=82.0.0",
+  "setuptools-scm[simple]>=8",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pkg_resources"
+requires-python = ">=3.9"
+dynamic = ["version"]
+dependencies = [
+  "packaging>=24.2",
+  "jaraco.text>=3.7",
+  "platformdirs >= 4.2.2", # Made ctypes optional (see #4461)
+]
+
+[project.optional-dependencies]
+test = [
+	# upstream
+	"pytest >= 6, != 8.1.*",
+
+	# local
+	"jaraco.path>=3.7.2", # Typing fixes
+	"setuptools>=82.0.0", # tests require distutils
+	"jaraco.envs>=2.2",
+]
+
+[tool.setuptools]
+packages = ["pkg_resources"]
+package-dir = {pkg_resources = "."}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version"]
 dependencies = [
   "packaging>=24.2",
   "jaraco.text>=3.7",
-  "platformdirs >= 4.2.2", # Made ctypes optional (see #4461)
+  "platformdirs >= 4.2.2", # Made ctypes optional (see pypa/setuptools#4461)
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import subprocess
+
+import jaraco.envs
+import pytest
+
+
+class VirtualEnv(jaraco.envs.VirtualEnv):
+    name = ".env"
+
+    def run(self, cmd, *args, **kwargs):
+        cmd = [self.exe(cmd[0])] + cmd[1:]
+        kwargs = {"cwd": self.root, "encoding": "utf-8", **kwargs}  # Allow overriding
+        return subprocess.check_output(cmd, *args, **kwargs)
+
+
+@pytest.fixture
+def venv(tmp_path, monkeypatch):
+    """Virtual env with the version of setuptools under test installed"""
+    env = VirtualEnv()
+    env.root = tmp_path / "venv"
+    env.req = "setuptools>=82.0.0"
+    # Prevents leaking PYTHONPATH at the environment creation
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    return env.create()

--- a/tests/test_integration_zope_interface.py
+++ b/tests/test_integration_zope_interface.py
@@ -1,5 +1,6 @@
 import platform
 from inspect import cleandoc
+from pathlib import Path
 
 import jaraco.path
 import pytest
@@ -15,12 +16,14 @@ pytestmark = pytest.mark.integration
     platform.system() != "Linux",
     reason="only demonstrated to fail on Linux in #4399",
 )
-def test_interop_pkg_resources_iter_entry_points(tmp_path, venv):
+def test_interop_pkg_resources_iter_entry_points(request, tmp_path, venv):
     """
     Importing pkg_resources.iter_entry_points on console_scripts
     seems to cause trouble with zope-interface, when deprecates installation method
     is used. See #4399.
     """
+
+    dep = f"pkg_resources @ {Path(request.config.rootdir).as_uri()}"
     project = {
         "pkg": {
             "foo.py": cleandoc(
@@ -32,23 +35,27 @@ def test_interop_pkg_resources_iter_entry_points(tmp_path, venv):
                 """
             ),
             "setup.py": cleandoc(
-                """
-                from setuptools import setup, find_packages
+                f"""
+                from setuptools import setup
 
                 setup(
-                    install_requires=["zope-interface==6.4.post2"],
-                    entry_points={
+                    install_requires=[
+                        "zope-interface==6.4.post2",
+                        {dep!r},
+                    ],
+                    entry_points={{
                         "console_scripts": [
                             "foo=foo:bar",
                         ],
-                    },
+                    }},
                 )
                 """
             ),
         }
     }
     jaraco.path.build(project, prefix=tmp_path)
-    cmd = ["pip", "install", "-e", ".", "--no-use-pep517"]
-    venv.run(cmd, cwd=tmp_path / "pkg")  # Needs this version of pkg_resources installed
+    cmd = ["pip", "install", "-e", ".", "--no-build-isolation"]
+    venv.run(cmd, cwd=tmp_path / "pkg")
+
     out = venv.run(["foo"])
     assert "Print me if you can" in out


### PR DESCRIPTION
In the case there is interest in revisiting this repo as a solution for the issue described in https://github.com/pypa/setuptools/issues/863#issuecomment-3872808142, this PR could be useful.

I run the very basic tests using `uvx --with ".[tests]" -m pytest`.

I did not want to cluter this particular PR with all the other files required to run tox/CI jobs, etc...
If there is interest, we can revisit that and implement the full CI.
